### PR TITLE
Fix header bottom border

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,3 +1,7 @@
+.d-header::after {
+    align-self: flex-end;
+}
+
 .topic-list .main-link a.title,
 .category-list .category-name,
 .latest-topic-list-item .main-link a.title


### PR DESCRIPTION
Using the theme CSS as-is (though with the color modified through Discourse's settings) caused this in the top bar:
[![Screenshot from Gyazo](https://gyazo.com/2454663021815fbb085955e235b78571/raw)](https://gyazo.com/2454663021815fbb085955e235b78571)

Adding the fix proposed here rendered it properly at the bottom:
[![Screenshot from Gyazo](https://gyazo.com/97694374f24568dc22097bd14ad2a3ab/raw)](https://gyazo.com/97694374f24568dc22097bd14ad2a3ab)